### PR TITLE
Matchers allow giving a timeout

### DIFF
--- a/lib/rx-rspec/async_runner.rb
+++ b/lib/rx-rspec/async_runner.rb
@@ -13,11 +13,11 @@ module RxRspec
       deadline = Time.now + @timeout
       done_args = nil
       error = nil
-      done = Proc.new do |*args|
-        done_args = args
-        condition.signal
-      end
       Thread.new do
+        done = Proc.new do |*args|
+          done_args = args unless done_args
+          condition.signal
+        end
         begin
           block.call(done)
         rescue => e
@@ -34,9 +34,9 @@ module RxRspec
       if error
         raise error
       elsif done_args.nil?
-        RSpec::Expectations.fail_with("Timeout after #{@timeout}")
+        RSpec::Expectations.fail_with("Timeout after #{@timeout} seconds")
       end
-      
+
       if done_args.nil? || done_args.size == 0
         nil
       else

--- a/lib/rx-rspec/async_runner.rb
+++ b/lib/rx-rspec/async_runner.rb
@@ -1,0 +1,41 @@
+require 'rspec'
+
+module RxRspec
+  class TimeoutError < RuntimeError ; end
+
+  class AsyncRunner
+    def initialize(timeout)
+      @timeout = timeout
+    end
+
+    def await_done(&block)
+      condition = ConditionVariable.new
+      deadline = Time.now + @timeout
+      done_called = false
+      error = nil
+      done = Proc.new do
+        done_called = true
+        condition.signal
+      end
+      Thread.new do
+        begin
+          block.call(done)
+        rescue => e
+          error = e
+          done.call
+        end
+      end.join(@timeout)
+
+      gate = Mutex.new
+      until Time.now >= deadline || done_called
+        gate.synchronize { condition.wait(gate, deadline - Time.now) }
+      end
+
+      if error
+        raise error
+      elsif !done_called
+        RSpec::Expectations.fail_with("Timeout after #{@timeout}")
+      end
+    end
+  end
+end

--- a/lib/rx-rspec/exactly.rb
+++ b/lib/rx-rspec/exactly.rb
@@ -6,15 +6,20 @@ RSpec::Matchers.define :emit_exactly do |*expected|
 
   match do |actual|
     events = []
-    error = await_done do |done|
-      actual.subscribe(
-        lambda do |event|
-          events << event
-          done.call if events.size > expected.size
-        end,
-        lambda { |err| done.call(:error, err) },
-        lambda { done.call }
-      )
+    begin
+      error = await_done do |done|
+        actual.subscribe(
+          lambda do |event|
+            events << event
+            done.call if events.size > expected.size
+          end,
+          lambda { |err| done.call(:error, err) },
+          lambda { done.call }
+        )
+      end
+    rescue Exception => err
+      @actual = [:error, err]
+      raise err
     end
 
     @actual = error || [:events, events]

--- a/lib/rx-rspec/exactly.rb
+++ b/lib/rx-rspec/exactly.rb
@@ -1,47 +1,34 @@
 require 'rspec'
 require 'rx-rspec/shared'
 
-# TODO:
-# - should have specific timeout message 'x seconds waiting for y'
-
 RSpec::Matchers.define :emit_exactly do |*expected|
   include RxRspec::Shared
 
-  events = []
-  errors = []
   match do |actual|
-    Thread.new do
-      spinlock = expected.size
+    events = []
+    error = await_done do |done|
       actual.subscribe(
         lambda do |event|
           events << event
-          spinlock -= 1
+          done.call if events.size > expected.size
         end,
-        lambda do |err|
-          errors << err
-          spinlock = 0
-        end,
-        lambda { spinlock = 0 }
+        lambda { |err| done.call(:error, err) },
+        lambda { done.call }
       )
-      for n in 1..10
-        break if spinlock == 0
-        sleep(0.05)
-      end
-      raise 'timeout' if spinlock > 0
-    end.join
+    end
 
-    return false unless errors.empty?
-    @actual = events
-    values_match? expected, events
+    @actual = error || [:events, events]
+    error.nil? && values_match?(expected, events)
   end
 
   diffable
 
   failure_message do
-    if errors.empty?
-      "expected #{events} to match #{expected}"
+    type, emitted = @actual
+    if type == :events
+      "expected #{emitted} to match #{expected}"
     else
-      present_error(expected, errors[0])
+      present_error(expected, emitted)
     end
   end
 end

--- a/lib/rx-rspec/first.rb
+++ b/lib/rx-rspec/first.rb
@@ -1,46 +1,34 @@
 require 'rspec'
 require 'rx-rspec/shared'
 
-# TODO:
-# - should have specific timeout message 'x seconds waiting for y'
-
 RSpec::Matchers.define :emit_first do |*expected|
   include RxRspec::Shared
-
-  events = []
-  errors = []
-  completed = []
 
   match do |actual|
     raise 'Please supply at least one expectation' if expected.size == 0
     expect_clone = expected.dup
-    Thread.new do
-      deadline = Time.now + 0.5
+    events = []
+    error = await_done do |done|
       actual.take_while do |event|
         events << event
         values_match?(expect_clone.shift, event) && expect_clone.size > 0
       end.subscribe(
         lambda { |event| },
-        lambda { |err| errors << err },
-        lambda { completed << :complete }
+        lambda { |err| done.call(:error, err) },
+        lambda { done.call }
       )
+    end
 
-      until Time.now > deadline
-        break if expect_clone.empty?
-        break unless completed.empty? && errors.empty?
-        sleep(0.05)
-      end
-      raise 'timeout' if Time.now > deadline
-    end.join
-
-    values_match? expected, events
+    @actual = error || [:events, events]
+    error.nil? && values_match?(expected, events)
   end
 
   failure_message do
-    if errors.empty?
-      "expected #{events} to emit at least #{expected}"
+    type, emitted = @actual
+    if type == :events
+      "expected #{emitted} to emit at least #{expected}"
     else
-      present_error(expected, errors[0])
+      present_error(expected, emitted)
     end
   end
 end

--- a/lib/rx-rspec/nothing.rb
+++ b/lib/rx-rspec/nothing.rb
@@ -5,12 +5,17 @@ RSpec::Matchers.define :emit_nothing do
   include RxRspec::Shared
 
   match do |actual|
-    @actual = await_done do |done|
-      actual.subscribe(
-        lambda { |event| done.call(:events, event) },
-        lambda { |err| done.call(:error, err) },
-        lambda { done.call }
-      )
+    begin
+      @actual = await_done do |done|
+        actual.subscribe(
+          lambda { |event| done.call(:events, event) },
+          lambda { |err| done.call(:error, err) },
+          lambda { done.call }
+        )
+      end
+    rescue Exception => err
+      @actual = [:error, err]
+      raise err
     end
     return @actual.nil?
   end

--- a/lib/rx-rspec/nothing.rb
+++ b/lib/rx-rspec/nothing.rb
@@ -1,39 +1,26 @@
 require 'rspec'
 require 'rx-rspec/shared'
 
-# TODO:
-# - should have specific timeout message 'x seconds waiting for y'
-
 RSpec::Matchers.define :emit_nothing do
   include RxRspec::Shared
 
-  events = []
-  errors = []
-  completed = []
   match do |actual|
-    Thread.new do
+    @actual = await_done do |done|
       actual.subscribe(
-        lambda { |event| events << event },
-        lambda { |err| errors << err },
-        lambda { completed << :complete }
+        lambda { |event| done.call(:events, event) },
+        lambda { |err| done.call(:error, err) },
+        lambda { done.call }
       )
-      for n in 1..10
-        break unless completed.empty?
-        break unless errors.empty? && events.empty?
-        sleep(0.05)
-      end
-      raise 'timeout' if errors.empty? && events.empty? && completed.empty?
-    end.join
-
-    return false unless errors.empty?
-    return events.empty?
+    end
+    return @actual.nil?
   end
 
   failure_message do
-    if errors.empty?
-      "unexpected #{events[0]} emitted"
+    type, emitted = @actual
+    if type == :events
+      "unexpected #{emitted} emitted"
     else
-      present_error(expected, errors[0])
+      present_error(expected, emitted)
     end
   end
 end

--- a/lib/rx-rspec/shared.rb
+++ b/lib/rx-rspec/shared.rb
@@ -5,6 +5,12 @@ module RxRspec
   module Shared
     DEFAULT_TIMEOUT = 0.5
 
+    def self.included(mod)
+      mod.chain :within do |seconds|
+        @timeout = seconds
+      end
+    end
+
     def timeout
       @timeout || DEFAULT_TIMEOUT
     end
@@ -15,6 +21,7 @@ module RxRspec
 
     def present_error(expected, error)
       backtrace = error.backtrace || []
+      return error.message if /^Timeout/.match(error.message)
       present_error = "#{error.inspect}:#{$/}#{backtrace.join($/)}"
       "expected #{expected} but received error #{present_error}"
     end

--- a/lib/rx-rspec/shared.rb
+++ b/lib/rx-rspec/shared.rb
@@ -1,3 +1,6 @@
+require 'rspec'
+require 'rx-rspec/async_runner'
+
 module RxRspec
   module Shared
     DEFAULT_TIMEOUT = 0.5
@@ -6,12 +9,8 @@ module RxRspec
       @timeout || DEFAULT_TIMEOUT
     end
 
-    # chain :within do |seconds|
-    #  @timeout = seconds
-    # end
-    
     def await_done(&block)
-      AsyncRunner.new(@timeout).await_done(&block)
+      AsyncRunner.new(timeout).await_done(&block)
     end
 
     def present_error(expected, error)

--- a/lib/rx-rspec/shared.rb
+++ b/lib/rx-rspec/shared.rb
@@ -9,6 +9,14 @@ module RxRspec
       mod.chain :within do |seconds|
         @timeout = seconds
       end
+
+      mod.description do
+        if @timeout
+          super() + " within #{@timeout} seconds"
+        else
+          super()
+        end
+      end
     end
 
     def timeout

--- a/lib/rx-rspec/shared.rb
+++ b/lib/rx-rspec/shared.rb
@@ -1,5 +1,19 @@
 module RxRspec
   module Shared
+    DEFAULT_TIMEOUT = 0.5
+
+    def timeout
+      @timeout || DEFAULT_TIMEOUT
+    end
+
+    # chain :within do |seconds|
+    #  @timeout = seconds
+    # end
+    
+    def await_done(&block)
+      AsyncRunner.new(@timeout).await_done(&block)
+    end
+
     def present_error(expected, error)
       backtrace = error.backtrace || []
       present_error = "#{error.inspect}:#{$/}#{backtrace.join($/)}"

--- a/spec/rx-rspec/async_runner_spec.rb
+++ b/spec/rx-rspec/async_runner_spec.rb
@@ -15,6 +15,14 @@ describe RxRspec::AsyncRunner do
       expect(Time.now - start).to be < 0.1
     end
 
+    it 'passes arguments to done on to caller' do
+      expect(runner.await_done {|done| done.call(1, 2) }).to eq([1, 2])
+    end
+
+    it 'passes nil to caller when done gets no arguments' do
+      expect(runner.await_done {|done| done.call }).to eq(nil)
+    end
+
     it 'raises timeout failure after timeout' do
       start = Time.now
       expect do
@@ -23,7 +31,7 @@ describe RxRspec::AsyncRunner do
       expect(Time.now - start).to be >= 0.2
       expect(Time.now - start).to be < 0.3
     end
-    
+
     it 'propagates exceptions from within the block' do
       start = Time.now
       expect do

--- a/spec/rx-rspec/async_runner_spec.rb
+++ b/spec/rx-rspec/async_runner_spec.rb
@@ -1,0 +1,37 @@
+require 'time'
+
+require 'rx-rspec/async_runner'
+
+describe RxRspec::AsyncRunner do
+  describe '#await_done' do
+    let(:timeout) { 0.2 }
+    let(:runner) { described_class.new(timeout) }
+
+    it 'supports announcing that the block is done' do
+      start = Time.now
+      runner.await_done do |done|
+        done.call
+      end
+      expect(Time.now - start).to be < 0.1
+    end
+
+    it 'raises timeout failure after timeout' do
+      start = Time.now
+      expect do
+        runner.await_done {|_| }
+      end.to fail_with(/timeout/i)
+      expect(Time.now - start).to be >= 0.2
+      expect(Time.now - start).to be < 0.3
+    end
+    
+    it 'propagates exceptions from within the block' do
+      start = Time.now
+      expect do
+        runner.await_done do |_|
+          raise 'badness'
+        end
+      end.to raise_error(/badness/)
+      expect(Time.now - start).to be < 0.1
+    end
+  end
+end

--- a/spec/rx-rspec/exactly_spec.rb
+++ b/spec/rx-rspec/exactly_spec.rb
@@ -10,6 +10,7 @@ describe '#emit_exactly matcher' do
   context 'given single-emitter observable' do
     subject { Rx::Observable.just(42) }
     it { should emit_exactly(42) }
+    it { should emit_exactly(42).within(0.1) }
   end
 
   context 'given single-emitter async observable' do

--- a/spec/rx-rspec/exactly_spec.rb
+++ b/spec/rx-rspec/exactly_spec.rb
@@ -52,4 +52,13 @@ describe '#emit_exactly matcher' do
       }.to fail_with match(/but received error.*MyException.*BOOM.*ze-traceback/m)
     end
   end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect {
+        should emit_exactly(1, 2).within(0.2)
+      }.to fail_with match(/timeout/i)
+    end
+  end
 end

--- a/spec/rx-rspec/first_spec.rb
+++ b/spec/rx-rspec/first_spec.rb
@@ -51,4 +51,13 @@ describe '#emit_first matcher' do
       }.to fail_with match(/but received error.*MyException.*BOOM/)
     end
   end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect {
+        should emit_first(1, 2).within(0.2)
+      }.to fail_with match(/timeout/i)
+    end
+  end
 end

--- a/spec/rx-rspec/first_spec.rb
+++ b/spec/rx-rspec/first_spec.rb
@@ -15,6 +15,7 @@ describe '#emit_first matcher' do
   context 'given single-emitter observable' do
     subject { Rx::Observable.just(42) }
     it { should emit_first(42) }
+    it { should emit_first(42).within(0.1) }
     it do
       expect {
         should emit_first(43)

--- a/spec/rx-rspec/include_spec.rb
+++ b/spec/rx-rspec/include_spec.rb
@@ -61,4 +61,13 @@ describe '#emit_include' do
       }.to fail_with match(/but received error.*MyException.*BOOM/)
     end
   end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect {
+        should emit_include(1).within(0.2)
+      }.to fail_with match(/timeout/i)
+    end
+  end
 end

--- a/spec/rx-rspec/include_spec.rb
+++ b/spec/rx-rspec/include_spec.rb
@@ -14,6 +14,7 @@ describe '#emit_include' do
   context 'given single-emitter observable' do
     subject { Rx::Observable.just(42) }
     it { should emit_include(42) }
+    it { should emit_include(42).within(0.1) }
   end
 
   context 'given single-emitter observable' do

--- a/spec/rx-rspec/nothing_spec.rb
+++ b/spec/rx-rspec/nothing_spec.rb
@@ -24,4 +24,13 @@ describe '#emit_nothing matcher' do
       }.to fail_with match(/but received error.*MyException.*BOOM/)
     end
   end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect {
+        should emit_nothing.within(0.2)
+      }.to fail_with match(/timeout/i)
+    end
+  end
 end

--- a/spec/rx-rspec/nothing_spec.rb
+++ b/spec/rx-rspec/nothing_spec.rb
@@ -5,6 +5,7 @@ describe '#emit_nothing matcher' do
   context 'given empty observable' do
     subject { Rx::Observable.empty }
     it { should emit_nothing }
+    it { should emit_nothing.within(0.1) }
   end
 
   context 'given single-emitter observable' do


### PR DESCRIPTION
This PR makes all matchers expose a `#within(<seconds>)` operators, such that you can write
```
expect(observable).to emit_exactly(42).within(0.1)
```
which will then fail after 0.1 seconds unless the criteria has been matched.

In order to make this change feasible, all matchers are refactored to use a common "runner" rather than creating their own threads. The runner is available as `await_done { |done| done.call }` on matchers including `RxRspec::Shared`.

Fixes #5 .