### PR TITLE
Matcher emit_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ end
 
 rx-spec include the following matchers:
 
-- **emit_nothing()** matches an observable that completes without emitting events or erroring.
-- **emit_exactly()** matches against all items produced by the observable and requires the observable to be completed.
-- **emit_first()** matches against the first elements of the observable, but does not require it to complete
-- **emit_include()** consumes elements until the expected elements have occurred
+- **emit_error(class, message)** matches an observable that errors without emitting any values.
+- **emit_exactly(*events)** matches an observable that emits exactly the given values and requires the observable to be completed.
+- **emit_first(*events)** matches against the first values emitted by the observable, but does not require it to complete.
+- **emit_include(*events)** consumes values until the expected values have been seen.
+- **emit_nothing()** matches an observable that completes without emitting values or erroring.

--- a/lib/rx-rspec/error.rb
+++ b/lib/rx-rspec/error.rb
@@ -1,0 +1,38 @@
+require 'rspec'
+require 'rx-rspec/shared'
+
+RSpec::Matchers.define :emit_error do
+  include RxRspec::Shared
+
+  match do |actual|
+    error_class, message = expected
+    begin
+      @actual = await_done do |done|
+        actual.subscribe(
+          lambda { |event| done.call(:events, event) },
+          lambda { |err| done.call(:error, err) },
+          lambda { done.call(:complete, nil) }
+        )
+      end
+    rescue Exception => err
+      @actual = [:error, err]
+      raise err
+    end
+    type, emitted = @actual
+    return type == :error &&
+      values_match?(error_class, emitted) &&
+      values_match?(message, emitted.message)
+  end
+
+  failure_message do
+    type, emitted = @actual
+    if type == :events
+      "unexpected #{emitted} emitted"
+    elsif type == :complete
+      "completed without error"
+    else
+      error_class, message = expected
+      present_error("#{error_class} with #{message}", emitted)
+    end
+  end
+end

--- a/spec/rx-rspec/error_spec.rb
+++ b/spec/rx-rspec/error_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'rx-rspec/error'
+
+describe '#emit_error matcher' do
+  context 'given empty observable' do
+    subject { Rx::Observable.empty }
+    it do
+      expect do
+        should emit_error(MyException, /BOOM/)
+      end.to fail_with(/completed without error/)
+    end
+  end
+
+  context 'given single-emitter observable' do
+    subject { Rx::Observable.just(42) }
+    it do
+      expect do
+        should emit_error(MyException, /BOOM/)
+      end.to fail_with(/unexpected 42 emitted/)
+    end
+  end
+
+  context 'given erroring observable with the expected exception' do
+    subject { Rx::Observable.raise_error(MyException.new('BOOM')) }
+    it { should emit_error(MyException, /BOOM/) }
+  end
+
+  context 'given erroring observable with an unexpected exception' do
+    subject { Rx::Observable.raise_error(RuntimeError.new('BOOM')) }
+    it do
+      expect do
+        should emit_error(MyException, /BOOM/)
+      end.to fail_with match(/but received.*RuntimeError.*BOOM/)
+    end
+  end
+
+  context 'given erroring observable with an unexpected message' do
+    subject { Rx::Observable.raise_error(MyException.new('BAM!')) }
+    it do
+      expect do
+        should emit_error(MyException, /BOOM/)
+      end.to fail_with match(/but received.*MyException.*BAM/)
+    end
+  end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect do
+        should emit_error(MyException, /BOOM/).within(0.2)
+      end.to fail_with match(/timeout/i)
+    end
+  end
+end


### PR DESCRIPTION
With this matcher you can assert that an observable emits an error. Unlike the built-in `raise_error` this matcher requires you to provide both class and message.
```
observable = Rx::Observable.raise_error(MyException.new('BOOM'))
expect(observable).to emit_error(MyException, /BOOM/)
```
Fixes #3.