### PR TITLE
Complete matcher

### DIFF
--- a/lib/rx-rspec/complete.rb
+++ b/lib/rx-rspec/complete.rb
@@ -1,0 +1,27 @@
+require 'rspec'
+require 'rx-rspec/shared'
+
+RSpec::Matchers.define :complete do
+  include RxRspec::Shared
+
+  match do |actual|
+    begin
+      @actual = await_done do |done|
+        actual.subscribe(
+          lambda { |_| },
+          lambda { |err| done.call(:error, err) },
+          lambda { done.call }
+        )
+      end
+    rescue Exception => err
+      @actual = [:error, err]
+      raise err
+    end
+    @actual.nil?
+  end
+
+  failure_message do
+    _, emitted = @actual
+    present_error(expected, emitted)
+  end
+end

--- a/spec/rx-rspec/complete_spec.rb
+++ b/spec/rx-rspec/complete_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'rx-rspec/complete'
+
+describe '#complete matcher' do
+  context 'given empty observable' do
+    subject { Rx::Observable.empty }
+    it { should complete }
+  end
+
+  context 'given single-emitter observable' do
+    subject { Rx::Observable.just(42) }
+    it { should complete }
+  end
+
+  context 'given single-emitter async observable' do
+    subject { Rx::Observable.just(42).delay(0) }
+    it { should complete }
+  end
+
+  context 'given erroring observable' do
+    subject { Rx::Observable.raise_error(MyException.new('BOOM')) }
+    it do
+      expect {
+        should complete
+      }.to fail_with match(/but received error.*MyException.*BOOM/)
+    end
+  end
+
+  context 'given a non-completing observable' do
+    subject { Rx::Observable.create { |_| } }
+    it do
+      expect {
+        should complete.within(0.2)
+      }.to fail_with match(/timeout/i)
+    end
+  end
+end


### PR DESCRIPTION
This matcher simply discards all emitted values and expects the observable to complete. This is useful when you want to assert on the side-effects of an observable.

Fixes #6.